### PR TITLE
Use 'cfg=target' for pusher binary

### DIFF
--- a/container/push.bzl
+++ b/container/push.bzl
@@ -205,7 +205,7 @@ container_push_ = rule(
         ),
         "_pusher": attr.label(
             default = "//container/go/cmd/pusher",
-            cfg = "exec",
+            cfg = "target",
             executable = True,
             allow_files = True,
         ),

--- a/contrib/push-all.bzl
+++ b/contrib/push-all.bzl
@@ -126,7 +126,7 @@ container_push = rule(
         ),
         "_pusher": attr.label(
             default = Label("//container/go/cmd/pusher"),
-            cfg = "exec",
+            cfg = "target",
             executable = True,
             allow_files = True,
         ),


### PR DESCRIPTION
In container_push rule, `_pusher` executable is copied into the output
runfiles, but not directly invoked _by_ the container_push rule.  This
binary could potentially be cross-compiled by other remote executors,
and should use the 'target' config in this action.